### PR TITLE
suppress app logs as they are noisy

### DIFF
--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,1 @@
-/opt/obsidian/obsidian --no-sandbox
+obsidian

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
-<item label="Obsidian" icon="/opt/obsidian/obsidian.png"><action name="Execute"><command>/opt/obsidian/obsidian --no-sandbox</command></action></item>
+<item label="Obsidian" icon="/opt/obsidian/obsidian.png"><action name="Execute"><command>/usr/bin/obsidian</command></action></item>
 <item label="Chromium" icon="/usr/share/icons/hicolor/48x48/apps/chromium.png"><action name="Execute"><command>/usr/bin/chromium</command></action></item>
 <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
 </menu>

--- a/root/usr/bin/obsidian
+++ b/root/usr/bin/obsidian
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+BIN=/opt/obsidian/obsidian
+
+# Run normally on privved containers or modified un non priv
+if grep -q 'Seccomp:.0' /proc/1/status; then
+  ${BIN} \
+   "$@" > /dev/null 2>&1
+else
+  ${BIN} \
+  --no-sandbox \
+   "$@" > /dev/null 2>&1
+fi


### PR DESCRIPTION
Just like we do with chromium suppress the logs for the electron app. 

The thing is with desktop application your only options are really to go down this line: 

1. remove the dri mount
2. run in seccomp unconfined
3. see if it works without a volume mounted in for `/config` (FUSE and other non compatible mounts)

Outside of that it either works or it does not, the application logs are never really helpful on a desktop application and will be noisy running inside of Docker way out of it's comfort zone with no dbus or systemd. 