### PR TITLE
fix Kasm init and run chown in autostart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ RUN \
   chmod +x /tmp/obsidian.app && \
   ./obsidian.app --appimage-extract && \
   mv squashfs-root /opt/obsidian && \
+  cp \
+    /opt/obsidian/usr/share/icons/hicolor/512x512/apps/obsidian.png \
+    /usr/share/icons/hicolor/512x512/apps/obsidian.png && \
   echo "**** cleanup ****" && \
   apt-get autoclean && \
   rm -rf \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -38,6 +38,9 @@ RUN \
   chmod +x /tmp/obsidian.app && \
   ./obsidian.app --appimage-extract && \
   mv squashfs-root /opt/obsidian && \
+  cp \
+    /opt/obsidian/usr/share/icons/hicolor/512x512/apps/obsidian.png \
+    /usr/share/icons/hicolor/512x512/apps/obsidian.png && \
   echo "**** cleanup ****" && \
   apt-get autoclean && \
   rm -rf \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -96,4 +96,5 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "18.06.24:", desc: "Fix application init for Kasm." }
   - { date: "06.04.24:", desc: "Initial release." }

--- a/root/defaults/autostart
+++ b/root/defaults/autostart
@@ -1,1 +1,5 @@
+if [ "$(whoami)" != "abc" ]; then
+  sudo lsiown -R $(id -u):$(id -u) \
+    /opt/obsidian
+fi
 obsidian

--- a/root/defaults/menu.xml
+++ b/root/defaults/menu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openbox_menu xmlns="http://openbox.org/3.4/menu">
 <menu id="root-menu" label="MENU">
-<item label="Obsidian" icon="/opt/obsidian/obsidian.png"><action name="Execute"><command>/usr/bin/obsidian</command></action></item>
+<item label="Obsidian" icon="/usr/share/icons/hicolor/512x512/apps/obsidian.png"><action name="Execute"><command>/usr/bin/obsidian</command></action></item>
 <item label="Chromium" icon="/usr/share/icons/hicolor/48x48/apps/chromium.png"><action name="Execute"><command>/usr/bin/chromium</command></action></item>
 <item label="xterm" icon="/usr/share/pixmaps/xterm-color_48x48.xpm"><action name="Execute"><command>/usr/bin/xterm</command></action></item>
 </menu>


### PR DESCRIPTION
Kasminit does not run s6, this will run a sudo chown in autostart if needed and moves the application icon out of this directory. 