### PR TITLE
make wayland default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,10 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="quietsy"
 
 # title
-ENV TITLE=Obsidian
+ENV TITLE=Obsidian \
+    NO_GAMEPAD=true \
+    NO_DECOR=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -8,7 +8,10 @@ LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DA
 LABEL maintainer="quietsy"
 
 # title
-ENV TITLE=Obsidian
+ENV TITLE=Obsidian \
+    NO_GAMEPAD=true \
+    NO_DECOR=true \
+    PIXELFLUX_WAYLAND=true
 
 RUN \
   echo "**** add icon ****" && \

--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.04.26:** - Make Wayland default disable with PIXELFLUX_WAYLAND=false.
 * **20.03.26:** - Use Wayland ozone platform fixes scaling and acceleration.
 * **28.12.25:** - Add Wayland init logic.
 * **21.09.25:** - Rebase to Debian Trixie.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -109,6 +109,7 @@ init_diagram: |
   "obsidian:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "03.04.26:", desc: "Make Wayland default disable with PIXELFLUX_WAYLAND=false."}
   - {date: "20.03.26:", desc: "Use Wayland ozone platform fixes scaling and acceleration."}
   - {date: "28.12.25:", desc: "Add Wayland init logic."}
   - {date: "21.09.25:", desc: "Rebase to Debian Trixie."}


### PR DESCRIPTION
Upstream still needs to update their CEF, this needs GPU for proper scaling but not a regression from X11. Added no_decor as that is needed in both modes. 